### PR TITLE
add comments to commands in the docs about the sample URL

### DIFF
--- a/docs/pages/fragments/profile/login-access-key.mdx
+++ b/docs/pages/fragments/profile/login-access-key.mdx
@@ -1,3 +1,3 @@
 ```bash
-loft login https://my-loft.url.tld --access-key [ACCESS_KEY]
+loft login https://my-loft.url.tld --access-key [ACCESS_KEY] # Replace URL with your own
 ```

--- a/docs/pages/guides/onboarding.mdx
+++ b/docs/pages/guides/onboarding.mdx
@@ -31,7 +31,7 @@ Installing the Loft CLI lets you create spaces and retrieve kube-contexts for yo
 ## Login
 After installing the CLI, you must log in to Loft:
 ```bash
-loft login https://my-loft.url.tld
+loft login https://my-loft.url.tld # Replace URL with your own
 ```
 This command will generate an [access key](#access-keys) and securely store it on your computer, so the Loft CLI can authenticate when running any further commands.
 


### PR DESCRIPTION
A user in Slack mentioned folks were trying to use the sample URL in the onboarding guide.