### PR TITLE
docs: require space and vcluster names for delete commands

### DIFF
--- a/docs/pages/commands/loft_delete_space.md
+++ b/docs/pages/commands/loft_delete_space.md
@@ -10,7 +10,7 @@ Deletes a space from a cluster
 
 
 ```
-loft delete space [flags]
+loft delete space [name] [flags]
 ```
 
 ```
@@ -20,7 +20,6 @@ loft delete space [flags]
 Deletes a space from a cluster.
 
 Example:
-loft delete space 
 loft delete space myspace
 loft delete space myspace --cluster mycluster
 #######################################################

--- a/docs/pages/commands/loft_delete_vcluster.md
+++ b/docs/pages/commands/loft_delete_vcluster.md
@@ -10,7 +10,7 @@ Deletes a virtual cluster from a cluster
 
 
 ```
-loft delete vcluster [flags]
+loft delete vcluster [name] [flags]
 ```
 
 ```


### PR DESCRIPTION
### Changes
- Update docs for `loft delete space` and `loft delete vcluster`. Related to https://github.com/loft-sh/loft-enterprise/pull/372