### PR TITLE
Additional annotation support for helm chart.

### DIFF
--- a/charts/loft/templates/deployment.yaml
+++ b/charts/loft/templates/deployment.yaml
@@ -11,9 +11,14 @@ metadata:
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.annotations }}
+  {{- if or .Values.annotations .Values.commonAnnotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- with .Values.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.commonAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   selector:

--- a/charts/loft/templates/ingress.yaml
+++ b/charts/loft/templates/ingress.yaml
@@ -26,6 +26,9 @@ metadata:
     {{- with .Values.ingress.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- with .Values.commonAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/loft/templates/pvc.yaml
+++ b/charts/loft/templates/pvc.yaml
@@ -4,6 +4,10 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ template "loft.fullname" . }}-audit
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   accessModes: ["ReadWriteOnce"]
   storageClassName: {{ .Values.audit.persistence.storageClassName }}

--- a/charts/loft/templates/rbac/clusterrolebinding.yaml
+++ b/charts/loft/templates/rbac/clusterrolebinding.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "loft.serviceAccountName" . }}

--- a/charts/loft/templates/secret.yaml
+++ b/charts/loft/templates/secret.yaml
@@ -6,6 +6,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: pre-install
+  {{- if or .Values.commonAnnotations .Values.secretAnnotations }}
+    {{- with .Values.secretAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.commonAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 data:
   config: {{ toYaml .Values.config | b64enc }}
 {{- end }}

--- a/charts/loft/templates/service.yaml
+++ b/charts/loft/templates/service.yaml
@@ -12,9 +12,14 @@ metadata:
     {{- with .Values.service.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.service.annotations }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- with .Values.service.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.commonAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/loft/templates/serviceaccount.yaml
+++ b/charts/loft/templates/serviceaccount.yaml
@@ -9,6 +9,15 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- with .Values.serviceAccount.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.commonAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}

--- a/charts/loft/values.yaml
+++ b/charts/loft/values.yaml
@@ -42,6 +42,12 @@ tls:
 # Additional annotations for the loft pod
 # podAnnotations: {}
 
+# Additional common annotations for all resources
+# commonAnnotations: {}
+
+# Annotations for the loft-config secret
+# secretAnnotations: {}
+
 # Additional labels for the loft pod
 # podLabels: {}
 
@@ -99,6 +105,7 @@ serviceAccount:
   name: loft
   create: true
   clusterRole: cluster-admin
+  annotations: {}
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Adds support for further defining annotations via values.yaml

- `.Values.commonAnnotations` added to `Deployment`, `ClusteRoleBinding`, `Ingress`, `PVC`, `Secret`, `Service`, `ServiceAccount` resources
- `.Values.secretAnnotations` added only to the `loft-config` Secret
- `.Values.serviceAccount.annotations` added only to the `ServiceAccount`