### PR TITLE
fix wrong path of loft-architecture.svg file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@
 
 ## Architecture
 
-![loft architecture](docs/static/media/loft-architecture.svg)
+![loft architecture](docs/static/media/v1/loft-architecture.svg)
 
 <br>


### PR DESCRIPTION
issue: can't show the architecture due to the wrong path
solve: fix the path