### PR TITLE
Helm chart improvements

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -27,7 +27,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClass }}
   ingressClassName: {{ .Values.ingress.ingressClass }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:
@@ -49,6 +51,8 @@ spec:
   tls:
     - hosts:
         - {{ .Values.ingress.host }}
+      {{- if .Values.ingress.tls.secret }}
       secretName: {{ .Values.ingress.tls.secret }}
+      {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,7 +25,6 @@ ingress:
   tls:
     enabled: true
     secret: loft-tls
-    clusterIssuer: lets-encrypt-http-issuer
 
 # TLS configuration with a custom cert and key
 # Make sure the secret exists prior to deploying loft,


### PR DESCRIPTION
## What

- make some Ingress fields optional
  - the `ingressClassName` cannot always be used if your ingress controller is still using the ingress annotation `kubernetes.io/ingress.class`. k8s only allows you to use the annotation or `ingressClassName`. With this change we can use that annotation and not use `ingressClassName
  - Make TLS secret optional. On some ingress controllers like `ingress-nginx` if you do not specify the `tls.hosts[].secretName` field, then the ingress controller will use a default certificate.
- Remove unused helm value: https://github.com/loft-sh/loft/issues/258