### PR TITLE
chore: fix download urls for loft CLI

### DIFF
--- a/docs/pages/cli/_partials/install.mdx
+++ b/docs/pages/cli/_partials/install.mdx
@@ -27,28 +27,28 @@ yarn global add loft.sh
 <TabItem value="mac">
 
 ```bash
-curl -L -o loft "https://github.com/loft-sh/loft/releases/latest/download/loft-darwin-amd64" && sudo install -c -m 0755 loft /usr/local/bin
+curl -L -o loft "https://github.com/loft-sh/loft/releases/download/v3.4.9/loft-darwin-amd64" && sudo install -c -m 0755 loft /usr/local/bin
 ```
 
 </TabItem>
 <TabItem value="mac-arm">
 
 ```bash
-curl -L -o loft "https://github.com/loft-sh/loft/releases/latest/download/loft-darwin-arm64" && sudo install -c -m 0755 loft /usr/local/bin
+curl -L -o loft "https://github.com/loft-sh/loft/releases/download/v3.4.9/loft-darwin-arm64" && sudo install -c -m 0755 loft /usr/local/bin
 ```
 
 </TabItem>
 <TabItem value="linux">
 
 ```bash
-curl -L -o loft "https://github.com/loft-sh/loft/releases/latest/download/loft-linux-amd64" && sudo install -c -m 0755 loft /usr/local/bin
+curl -L -o loft "https://github.com/loft-sh/loft/releases/download/v3.4.9/loft-linux-amd64" && sudo install -c -m 0755 loft /usr/local/bin
 ```
 
 </TabItem>
 <TabItem value="linux-arm">
 
 ```bash
-curl -L -o loft "https://github.com/loft-sh/loft/releases/latest/download/loft-linux-arm64" && sudo install -c -m 0755 loft /usr/local/bin
+curl -L -o loft "https://github.com/loft-sh/loft/releases/download/v3.4.9/loft-linux-arm64" && sudo install -c -m 0755 loft /usr/local/bin
 ```
 
 </TabItem>
@@ -56,7 +56,7 @@ curl -L -o loft "https://github.com/loft-sh/loft/releases/latest/download/loft-l
 
 ```powershell {4}
 md -Force "$Env:APPDATA\loft"; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12';
-Invoke-WebRequest -URI "https://github.com/loft-sh/loft/releases/latest/download/loft-windows-amd64.exe" -o $Env:APPDATA\loft\loft.exe;
+Invoke-WebRequest -URI "https://github.com/loft-sh/loft/releases/download/v3.4.9/loft-windows-amd64.exe" -o $Env:APPDATA\loft\loft.exe;
 $env:Path += ";" + $Env:APPDATA + "\loft";
 [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User);
 ```

--- a/docs/versioned_docs/version-3.4/cli/_partials/install.mdx
+++ b/docs/versioned_docs/version-3.4/cli/_partials/install.mdx
@@ -27,28 +27,28 @@ yarn global add loft.sh
 <TabItem value="mac">
 
 ```bash
-curl -L -o loft "https://github.com/loft-sh/loft/releases/latest/download/loft-darwin-amd64" && sudo install -c -m 0755 loft /usr/local/bin
+curl -L -o loft "https://github.com/loft-sh/loft/releases/download/v3.4.9/loft-darwin-amd64" && sudo install -c -m 0755 loft /usr/local/bin
 ```
 
 </TabItem>
 <TabItem value="mac-arm">
 
 ```bash
-curl -L -o loft "https://github.com/loft-sh/loft/releases/latest/download/loft-darwin-arm64" && sudo install -c -m 0755 loft /usr/local/bin
+curl -L -o loft "https://github.com/loft-sh/loft/releases/download/v3.4.9/loft-darwin-arm64" && sudo install -c -m 0755 loft /usr/local/bin
 ```
 
 </TabItem>
 <TabItem value="linux">
 
 ```bash
-curl -L -o loft "https://github.com/loft-sh/loft/releases/latest/download/loft-linux-amd64" && sudo install -c -m 0755 loft /usr/local/bin
+curl -L -o loft "https://github.com/loft-sh/loft/releases/download/v3.4.9/loft-linux-amd64" && sudo install -c -m 0755 loft /usr/local/bin
 ```
 
 </TabItem>
 <TabItem value="linux-arm">
 
 ```bash
-curl -L -o loft "https://github.com/loft-sh/loft/releases/latest/download/loft-linux-arm64" && sudo install -c -m 0755 loft /usr/local/bin
+curl -L -o loft "https://github.com/loft-sh/loft/releases/download/v3.4.9/loft-linux-arm64" && sudo install -c -m 0755 loft /usr/local/bin
 ```
 
 </TabItem>
@@ -56,7 +56,7 @@ curl -L -o loft "https://github.com/loft-sh/loft/releases/latest/download/loft-l
 
 ```powershell {4}
 md -Force "$Env:APPDATA\loft"; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12';
-Invoke-WebRequest -URI "https://github.com/loft-sh/loft/releases/latest/download/loft-windows-amd64.exe" -o $Env:APPDATA\loft\loft.exe;
+Invoke-WebRequest -URI "https://github.com/loft-sh/loft/releases/download/v3.4.9/loft-windows-amd64.exe" -o $Env:APPDATA\loft\loft.exe;
 $env:Path += ";" + $Env:APPDATA + "\loft";
 [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User);
 ```


### PR DESCRIPTION
Closes DOC-337

[Download and Install Loft CLI Preview - master](https://deploy-preview-268--loft-docs.netlify.app/docs/master/getting-started/install)
[Download and Install Loft CLI Preview 3.4](https://deploy-preview-268--loft-docs.netlify.app/docs/getting-started/install)