### PR TITLE
updated the reference config url to vcluster platform

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -163,7 +163,7 @@ serviceMonitor:
   labels: {}
 
 # Loft config to use, all options can be seen at:
-# https://loft.sh/docs/admin/config
+# https://www.vcluster.com/docs/platform/configure/config
 config:
   audit:
     enabled: true


### PR DESCRIPTION
Updated reference URL for config from https://loft.sh/docs/admin/config to https://www.vcluster.com/docs/platform/configure/config